### PR TITLE
Fix check for migrating old configuration settings

### DIFF
--- a/app/code/community/PostcodeNl/Api/data/postcodenl_api_setup/data-upgrade-1.0.8.0-1.1.0.0.php
+++ b/app/code/community/PostcodeNl/Api/data/postcodenl_api_setup/data-upgrade-1.0.8.0-1.1.0.0.php
@@ -12,7 +12,7 @@ $serviceNeverHideCountry = Mage::getStoreConfig('postcodenl/config/never_hide_co
 $serviceUseStreet2AsHousenumber = Mage::getStoreConfig('postcodenl/config/use_street2_as_housenumber');
 
 // Only do update, if we actually have old configuration (secret being most important to check)
-if ($serviceSecret !== null)
+if ($serviceSecret !== '')
 {
 	// Set new basic configuration
 	$config->saveConfig('postcodenl_api/config/enabled', $serviceEnabled, 'default', 0);


### PR DESCRIPTION
The check whether there is an old configuration always returns true, even for new installations: the call to Mage::getStoreConfig('postcodenl/config/api_secret') returns either null (new installations) or a string (old installations), but the call to trim always results in a string; therefore the !== null comparison always returns true.