### PR TITLE
Prevent an infinite loop when changing the country select

### DIFF
--- a/js/postcodenl/api/lookup.js
+++ b/js/postcodenl/api/lookup.js
@@ -553,7 +553,10 @@ document.observe("dom:loaded", PCNL_START_FUNCTION = function()
 			if ($(prefix + countryFieldId).getValue() == '')
 			{
 				$(prefix + countryFieldId).setValue('NL');
-				pcnlFireEvent($(prefix + countryFieldId), 'change');
+				if ($F(prefix + countryFieldId) == 'NL') {
+					// only fire the event if the value has actually changed (i.e. the 'NL' value exists)
+					pcnlFireEvent($(prefix + countryFieldId), 'change');
+				}
 			}
 
 			if ($(prefix + countryFieldId).getValue() == 'NL')


### PR DESCRIPTION
Prevent an infinite loop when changing the country select and there is no 'NL' option in the select box

The script will result in an endless recursion when there is no option with the value 'NL' in the select element, as the value of the select is still empty after setting its value to 'NL'.