### PR TITLE
Fixed duplicate header 'Content-Type'

### DIFF
--- a/app/code/community/PostcodeNl/Api/controllers/Adminhtml/PcnlController.php
+++ b/app/code/community/PostcodeNl/Api/controllers/Adminhtml/PcnlController.php
@@ -9,7 +9,7 @@ class PostcodeNl_Api_Adminhtml_PcnlController extends Mage_Adminhtml_Controller_
 		if ($this->getRequest()->getParam('et'))
 			$helper->setEnrichType($this->getRequest()->getParam('et'));
 
-		$this->getResponse()->setHeader('Content-type', 'application/json');
+		$this->getResponse()->setHeader('Content-type', 'application/json', true);
 		$this->getResponse()->setBody(json_encode($helper->lookupAddress(
 			$this->getRequest()->getParam('postcode'),
 			$this->getRequest()->getParam('houseNumber'),

--- a/app/code/community/PostcodeNl/Api/controllers/JsonController.php
+++ b/app/code/community/PostcodeNl/Api/controllers/JsonController.php
@@ -9,7 +9,7 @@ class PostcodeNl_Api_JsonController extends Mage_Core_Controller_Front_Action
 		if ($this->getRequest()->getParam('et'))
 			$helper->setEnrichType($this->getRequest()->getParam('et'));
 
-		$this->getResponse()->setHeader('Content-type', 'application/json');
+		$this->getResponse()->setHeader('Content-type', 'application/json', true);
 		$this->getResponse()->setBody(json_encode($helper->lookupAddress(
 			$this->getRequest()->getParam('postcode'),
 			$this->getRequest()->getParam('houseNumber'),


### PR DESCRIPTION
On PHP7.0 you get the: error parsing headers: duplicate header
'Content-Type'

This fixes the issue