### PR TITLE
Improve error handling

### DIFF
--- a/app/code/community/PostcodeNl/Api/Helper/Data.php
+++ b/app/code/community/PostcodeNl/Api/Helper/Data.php
@@ -171,22 +171,16 @@ class PostcodeNl_Api_Helper_Data extends Mage_Core_Helper_Abstract
 				}
 				else
 				{
-					$response['message'] = $this->__('Validation error, please use manual input.');
-					$response['messageTarget'] = 'housenumber';
-					$response['useManual'] = true;
+					$response = array_merge($response, $this->_errorResponse());
 				}
 			}
 			else
 			{
-				$response['message'] = $this->__('Validation unavailable, please use manual input.');
-				$response['messageTarget'] = 'housenumber';
-				$response['useManual'] = true;
+				$response = array_merge($response, $this->_errorResponse());
 			}
 
 		} catch (Exception $e) {
-			$response['message'] = $this->__('Validation unavailable, please use manual input.');
-			$response['messageTarget'] = 'housenumber';
-			$response['useManual'] = true;
+			$response = array_merge($response, $this->_errorResponse());
 		}
 
 		return $response;
@@ -466,5 +460,14 @@ class PostcodeNl_Api_Helper_Data extends Mage_Core_Helper_Abstract
 			}
 		}
 		return $this->_modules;
+	}
+
+	protected function _errorResponse()
+	{
+		return [
+			'message' => $this->__('Validation error, please use manual input.'),
+			'messageTarget' => 'housenumber',
+			'useManual' => true,
+		];
 	}
 }

--- a/app/code/community/PostcodeNl/Api/Helper/Data.php
+++ b/app/code/community/PostcodeNl/Api/Helper/Data.php
@@ -111,72 +111,79 @@ class PostcodeNl_Api_Helper_Data extends Mage_Core_Helper_Abstract
 			return $message;
 
 		$response = array();
+		
+		try {
+			// Some basic user data 'fixing', remove any not-letter, not-number characters
+			$postcode = preg_replace('~[^a-z0-9]~i', '', $postcode);
 
-		// Some basic user data 'fixing', remove any not-letter, not-number characters
-		$postcode = preg_replace('~[^a-z0-9]~i', '', $postcode);
-
-		// Basic postcode format checking
-		if (!preg_match('~^[1-9][0-9]{3}[a-z]{2}$~i', $postcode))
-		{
-			$response['message'] = $this->__('Invalid postcode format, use `1234AB` format.');
-			$response['messageTarget'] = 'postcode';
-			return $response;
-		}
-
-		$url = $this->_getServiceUrl() . '/rest/addresses/' . rawurlencode($postcode). '/'. rawurlencode($houseNumber) . '/'. rawurlencode($houseNumberAddition);
-
-		$jsonData = $this->_callApiUrlGet($url);
-
-		if ($this->_getStoreConfig('postcodenl_api/development_config/api_showcase'))
-			$response['showcaseResponse'] = $jsonData;
-
-		if ($this->isDebugging())
-			$response['debugInfo'] = $this->_getDebugInfo($url, $jsonData);
-
-		if ($this->_httpResponseCode == 200 && is_array($jsonData) && isset($jsonData['postcode']))
-		{
-			$response = array_merge($response, $jsonData);
-		}
-		else if (is_array($jsonData) && isset($jsonData['exceptionId']))
-		{
-			if ($this->_httpResponseCode == 400 || $this->_httpResponseCode == 404)
+			// Basic postcode format checking
+			if (!preg_match('~^[1-9][0-9]{3}[a-z]{2}$~i', $postcode))
 			{
-				switch ($jsonData['exceptionId'])
+				$response['message'] = $this->__('Invalid postcode format, use `1234AB` format.');
+				$response['messageTarget'] = 'postcode';
+				return $response;
+			}
+
+			$url = $this->_getServiceUrl() . '/rest/addresses/' . rawurlencode($postcode). '/'. rawurlencode($houseNumber) . '/'. rawurlencode($houseNumberAddition);
+
+			$jsonData = $this->_callApiUrlGet($url);
+
+			if ($this->_getStoreConfig('postcodenl_api/development_config/api_showcase'))
+				$response['showcaseResponse'] = $jsonData;
+
+			if ($this->isDebugging())
+				$response['debugInfo'] = $this->_getDebugInfo($url, $jsonData);
+
+			if ($this->_httpResponseCode == 200 && is_array($jsonData) && isset($jsonData['postcode']))
+			{
+				$response = array_merge($response, $jsonData);
+			}
+			else if (is_array($jsonData) && isset($jsonData['exceptionId']))
+			{
+				if ($this->_httpResponseCode == 400 || $this->_httpResponseCode == 404)
 				{
-					case 'PostcodeNl_Controller_Address_PostcodeTooShortException':
-					case 'PostcodeNl_Controller_Address_PostcodeTooLongException':
-					case 'PostcodeNl_Controller_Address_NoPostcodeSpecifiedException':
-					case 'PostcodeNl_Controller_Address_InvalidPostcodeException':
-						$response['message'] = $this->__('Invalid postcode format, use `1234AB` format.');
-						$response['messageTarget'] = 'postcode';
-						break;
-					case 'PostcodeNl_Service_PostcodeAddress_AddressNotFoundException':
-						$response['message'] = $this->__('Unknown postcode + housenumber combination.');
-						$response['messageTarget'] = 'housenumber';
-						break;
-					case 'PostcodeNl_Controller_Address_InvalidHouseNumberException':
-					case 'PostcodeNl_Controller_Address_NoHouseNumberSpecifiedException':
-					case 'PostcodeNl_Controller_Address_NegativeHouseNumberException':
-					case 'PostcodeNl_Controller_Address_HouseNumberTooLargeException':
-					case 'PostcodeNl_Controller_Address_HouseNumberIsNotAnIntegerException':
-						$response['message'] = $this->__('Housenumber format is not valid.');
-						$response['messageTarget'] = 'housenumber';
-						break;
-					default:
-						$response['message'] = $this->__('Incorrect address.');
-						$response['messageTarget'] = 'housenumber';
-						break;
+					switch ($jsonData['exceptionId'])
+					{
+						case 'PostcodeNl_Controller_Address_PostcodeTooShortException':
+						case 'PostcodeNl_Controller_Address_PostcodeTooLongException':
+						case 'PostcodeNl_Controller_Address_NoPostcodeSpecifiedException':
+						case 'PostcodeNl_Controller_Address_InvalidPostcodeException':
+							$response['message'] = $this->__('Invalid postcode format, use `1234AB` format.');
+							$response['messageTarget'] = 'postcode';
+							break;
+						case 'PostcodeNl_Service_PostcodeAddress_AddressNotFoundException':
+							$response['message'] = $this->__('Unknown postcode + housenumber combination.');
+							$response['messageTarget'] = 'housenumber';
+							break;
+						case 'PostcodeNl_Controller_Address_InvalidHouseNumberException':
+						case 'PostcodeNl_Controller_Address_NoHouseNumberSpecifiedException':
+						case 'PostcodeNl_Controller_Address_NegativeHouseNumberException':
+						case 'PostcodeNl_Controller_Address_HouseNumberTooLargeException':
+						case 'PostcodeNl_Controller_Address_HouseNumberIsNotAnIntegerException':
+							$response['message'] = $this->__('Housenumber format is not valid.');
+							$response['messageTarget'] = 'housenumber';
+							break;
+						default:
+							$response['message'] = $this->__('Incorrect address.');
+							$response['messageTarget'] = 'housenumber';
+							break;
+					}
+				}
+				else
+				{
+					$response['message'] = $this->__('Validation error, please use manual input.');
+					$response['messageTarget'] = 'housenumber';
+					$response['useManual'] = true;
 				}
 			}
 			else
 			{
-				$response['message'] = $this->__('Validation error, please use manual input.');
+				$response['message'] = $this->__('Validation unavailable, please use manual input.');
 				$response['messageTarget'] = 'housenumber';
 				$response['useManual'] = true;
 			}
-		}
-		else
-		{
+
+		} catch (Exception $e) {
 			$response['message'] = $this->__('Validation unavailable, please use manual input.');
 			$response['messageTarget'] = 'housenumber';
 			$response['useManual'] = true;

--- a/app/code/community/PostcodeNl/Api/Helper/Data.php
+++ b/app/code/community/PostcodeNl/Api/Helper/Data.php
@@ -168,7 +168,7 @@ class PostcodeNl_Api_Helper_Data extends Mage_Core_Helper_Abstract
 						break;
 				}
 			}
-			else if (is_array($jsonData) && isset($jsonData['exceptionId']))
+			else
 			{
 				$response['message'] = $this->__('Validation error, please use manual input.');
 				$response['messageTarget'] = 'housenumber';

--- a/app/code/community/PostcodeNl/Api/etc/jstranslator.xml
+++ b/app/code/community/PostcodeNl/Api/etc/jstranslator.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<jstranslator>
+    <postcode_use_manual translate="message" module="core">
+        <message>Validation error, please use manual input.</message>
+    </postcode_use_manual>
+</jstranslator>

--- a/js/postcodenl/api/lookup.js
+++ b/js/postcodenl/api/lookup.js
@@ -306,7 +306,12 @@ document.observe("dom:loaded", PCNL_START_FUNCTION = function()
 					method: 'get',
 					onException: function(transport, e)
 					{
-						throw e;
+						var json = {
+							'useManual' : true,
+							'messageTarget' : 'housenumber',
+							'message' : Translator.translate('Validation error, please use manual input.')
+						};
+						pcnlapi.updatePostcodeLookup(json, housenumber_addition, housenumber_addition_select, prefix, postcodeFieldId, countryFieldId, street1, street2, street3, street4, event);
 					},
 					onComplete: function(transport)
 					{


### PR DESCRIPTION
Customers were not able to continue with the checkout if the response was invalid. This happened regularly when the Postcode NL API was not available.

I added safeguards at two stages:

1. catch exceptions in PHP and return the "validation service error" resposne
2. handle exceptions in JS and fall back to manual input

The diff looks nicer with ignored whitespace.