### PR TITLE
Fix reference for 'same as billing' checkbox in admin

### DIFF
--- a/js/postcodenl/api/lookup.js
+++ b/js/postcodenl/api/lookup.js
@@ -1477,7 +1477,7 @@ document.observe("dom:loaded", PCNL_START_FUNCTION = function()
 		{
 			var pcnlapi = this;
 			// Shipping
-			if (!$('order-shipping_same_as_billing').checked)
+			if (!$('order-shipping_as_billing').checked)
 			{
 				$('order-shipping_address_postcode').observe('change', function(e)
 				{


### PR DESCRIPTION
If you create an order from the backend with PostcodeNL configured, the following error is logged to the console:

> Uncaught TypeError: Cannot read property 'checked' of null

This is because the "same as billing" checkbox is referenced by the wrong id